### PR TITLE
Update to Go 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine3.15 as builder
+FROM golang:1.20.1-alpine3.17 as builder
 
 # Install SSL ca certificates
 RUN apk update && apk add git && apk add ca-certificates
@@ -27,7 +27,7 @@ RUN GOOS=linux GOARCH=amd64 go build --tags=build -o /go/bin/analyzer .
 # Build a minimal and secured container
 # The ast parser needs Go installed for import statements.
 # Therefore, unfortunately we cannot build from scratch as we would normally do with Go.
-FROM golang:1.18-alpine3.15
+FROM golang:1.20.1-alpine3.17
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/bin /opt/analyzer/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exercism/go-analyzer
 
-go 1.18
+go 1.20
 
 require (
 	github.com/logrusorgru/aurora v0.0.0-20181002194514-a7b3b318ed4e


### PR DESCRIPTION
## Description

This PR prepares the analyzer for the track upgrade to Go 1.20:

- Set `go.mod` of the analyzer to Go 1.20
- Update Dockerfile

## Related

Other PRs related with the upgrade of the Go track to 1.20:

- [ ] Update representer: https://github.com/exercism/go-representer/pull/34
- [ ] Update main repo: https://github.com/exercism/go/pull/2609
- [ ]  Update test runner: https://github.com/exercism/go-test-runner/pull/97